### PR TITLE
Add support for syntax highlighting within Markdown code blocks

### DIFF
--- a/lib/components/ui/Markdown.js
+++ b/lib/components/ui/Markdown.js
@@ -1,10 +1,18 @@
 /* eslint react/no-danger:0 */
-
 import React, { PropTypes } from 'react';
-import marked from 'marked';
+import marked, { Renderer } from 'marked';
+import highlightjs from 'highlight.js';
 
 export default function Markdown({text}) {
-    const html = marked(text);
+    const renderer = new Renderer();
+
+    renderer.code = (code, language) => {
+        const highlight = highlightjs.highlight(language, code).value;
+        return `<pre><code class="hljs ${language}">${highlight}</code></pre>`
+    }
+
+    const html = marked(text, {renderer : renderer});
+
     return (
         <div dangerouslySetInnerHTML={{__html: html}} />
     );

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^4.2.3",
     "express": "^4.13.3",
+    "highlight.js": "^9.5.0",
     "jest-cli": "^0.9.2",
     "postcss": "^5.0.19",
     "postcss-cssnext": "^2.5.1",


### PR DESCRIPTION
Added the `highlight.js` package and changed the renderer to apply syntax highlighting when parsing markdown code blocks.