### PR TITLE
Move highlight.js to a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^4.2.3",
     "express": "^4.13.3",
-    "highlight.js": "^9.5.0",
     "jest-cli": "^0.9.2",
     "postcss": "^5.0.19",
     "postcss-cssnext": "^2.5.1",
@@ -40,6 +39,7 @@
   "dependencies": {
     "babel-loader": "^6.2.4",
     "css-loader": "^0.23.0",
+    "highlight.js": "^9.5.0",
     "history": "^1.17.0",
     "marked": "^0.3.5",
     "react": "^15.1.0",


### PR DESCRIPTION
Whoops, my bad. Moved highlight.js to be a dependency for the project, as opposed to a devDependency. Should be good now.